### PR TITLE
Widget loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- PATCH calls will search by user_id if one exists to handle authenticated users, while searching by dashboard_id when unauthenticated so calls for authenticated users can ignore the now-meaningless dashboard id value
+
+### Added
+- Separate GET dashboard call for authenticated users, so we're not causing any confusion by passing a meaningless dashboard id
+- Raises 404 error when we can't find workset in AG list of public or private worksets
+- Raises 422 error when trying to build a workset where no HTIDs are in TORCHLITE
+
+### Fixed
+- Handling of worksets when none are loading from Analytics Gateway
+
 ## [0.3.0] – 2025-02-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] – 2025-05-19
+
 ### Changed
 - PATCH calls will search by user_id if one exists to handle authenticated users, while searching by dashboard_id when unauthenticated so calls for authenticated users can ignore the now-meaningless dashboard id value
 
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file.
 - HTTPX client for mTLS connections to the registry to retrieve worksets. [#125](https://github.com/htrc/torchlite-backend/issues/125)
 
-[unreleased]: https://github.com/htrc/torchlite-backend/compare/0.3.0...HEAD
+[unreleased]: https://github.com/htrc/torchlite-backend/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/htrc/torchlite-backend/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/htrc/torchlite-backend/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/htrc/torchlite-backend/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/htrc/torchlite-backend/releases/tag/0.1.0

--- a/htrc/torchlite/managers/workset_manager.py
+++ b/htrc/torchlite/managers/workset_manager.py
@@ -53,8 +53,8 @@ class _WorksetManager:
     async def get_user_worksets(self, user_access_token: str | None) -> dict[str, WorksetSummary]:
         if self.user_worksets is None and user_access_token is not None:
             headers = {'Accept': 'application/json', 'Authorization': user_access_token}
-            response = await registry_http.get(f"{config.REGISTRY_API_URL}/worksets", headers=headers)
             try:
+                response = await registry_http.get(f"{config.REGISTRY_API_URL}/worksets", headers=headers)
                 data = json.loads(response.content)
 
                 self.user_worksets = {

--- a/htrc/torchlite/managers/workset_manager.py
+++ b/htrc/torchlite/managers/workset_manager.py
@@ -37,13 +37,16 @@ class _WorksetManager:
 
     async def get_public_worksets(self) -> dict[str, WorksetSummary]:
         if self.public_worksets is None:
-            headers = {'Accept': 'application/json'}
-            response = await registry_http.get(f"{config.REGISTRY_API_URL}/publicworksets", headers=headers)
-            data = json.loads(response.content)
-            self.public_worksets = {
-                workset['metadata']['id']: WorksetSummary.model_construct(numVolumes=workset['metadata']['volumeCount'],isPublic=workset['metadata']['public'],**workset['metadata'])
-                for workset in data['worksets']['workset'] if workset['metadata']['public']
-            }
+            try:
+                headers = {'Accept': 'application/json'}
+                response = await registry_http.get(f"{config.REGISTRY_API_URL}/publicworksets", headers=headers)
+                data = json.loads(response.content)
+                self.public_worksets = {
+                    workset['metadata']['id']: WorksetSummary.model_construct(numVolumes=workset['metadata']['volumeCount'],isPublic=workset['metadata']['public'],**workset['metadata'])
+                    for workset in data['worksets']['workset'] if workset['metadata']['public']
+                }
+            except Exception as e:
+                log.error(f'ERROR getting public worksets: {e}')
 
         return self.public_worksets
 

--- a/htrc/torchlite/managers/workset_manager.py
+++ b/htrc/torchlite/managers/workset_manager.py
@@ -27,7 +27,7 @@ class _WorksetManager:
         self.user_worksets = None
 
     def get_featured_worksets(self) -> dict[str, WorksetSummary]:
-        if self.featured_worksets is None:
+        if self.featured_worksets is None and self.public_worksets is not None:
             self.featured_worksets = {
                 workset: self.public_worksets[workset]
                 for workset in self.public_worksets if self.public_worksets[workset].author == config.FEATURED_WORKSET_USER

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -173,6 +173,7 @@ async def update_dashboard(dashboard_id: UUID,
     log.debug('j')
     if dashboard:
         log.debug('k')
+        log.debug(dashboard)
         try:
             log.debug('l')
             for w in dashboard.widgets:

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -56,7 +56,9 @@ async def list_dashboards(workset_manager: WorksetManager,
             mongo_client.db["dashboards"].find({"owner": config.TORCHLITE_UID, "isShared": True}).to_list(1000)
         )
         log.debug('returning featured worksets')
-        log.debug(workset_manager.public_worksets)
+        if not workset_manager.public_worksets:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+        
         return await workset_manager.align_featured_worksets(shared_torchlite_worksets)
 
     if not user:

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -80,8 +80,10 @@ async def create_dashboard(dashboard_create: DashboardCreate,
                            workset_manager: WorksetManager,
                            owner: UUID | None = None,
                            user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
+    log.debug('create_dashboard')
     user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
     owner = owner or user_id
+    log.debug(owner)
 
     if user_id != owner:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
@@ -148,6 +150,9 @@ async def update_dashboard(dashboard_id: UUID,
     log.debug('h')
     dashboard_patch_update = DashboardPatchUpdate(**dashboard_patch.model_dump(exclude_defaults=True))
     log.debug('i')
+    log.debug(dashboard_patch_update)
+    log.debug(dashboard_id)
+    log.debug(user_id)
     dashboard = await DashboardSummary.from_mongo(
         mongo_client.db["dashboards"].find_one_and_update(
             filter={"_id": dashboard_id, "owner": user_id},

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -119,7 +119,17 @@ async def get_dashboard(dashboard_id: UUID,
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         else:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+        
+@router.get("/private", description="Retrieve a private dashboard", response_model_exclude_defaults=True)
+async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
+    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
 
+    dashboard = await DashboardSummary.from_mongo(
+        mongo_client.db["dashboards"].find_one({"owner": user_id})
+    )
+    if dashboard:
+        log.debug("PRIVATE DASHBOARD")
+        log.debug(dashboard)
 
 @router.patch("/{dashboard_id}", description="Update a dashboard", response_model_exclude_defaults=True)
 async def update_dashboard(dashboard_id: UUID,

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -102,6 +102,24 @@ async def create_dashboard(dashboard_create: DashboardCreate,
     return dashboard
 
 
+@router.get("/private", description="Retrieve a private dashboard", response_model_exclude_defaults=True)
+async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
+    log.debug("get_private_dashboard")
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) 
+#    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
+#
+#    dashboard = await DashboardSummary.from_mongo(
+#        mongo_client.db["dashboards"].find_one({"owner": user_id})
+#    )
+#    if dashboard:
+#        log.debug("PRIVATE DASHBOARD")
+#        log.debug(dashboard)
+#        return dashboard
+#    else:
+#        log.error('Dashboard get error')
+#        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
 @router.get("/{dashboard_id}", description="Retrieve a dashboard", response_model_exclude_defaults=True)
 @cache(key_builder=request_key_builder)
 async def get_dashboard(dashboard_id: UUID,
@@ -120,22 +138,6 @@ async def get_dashboard(dashboard_id: UUID,
         else:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
         
-@router.get("/private", description="Retrieve a private dashboard", response_model_exclude_defaults=True)
-async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
-    log.debug("get_private_dashboard")
-    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) 
-#    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
-#
-#    dashboard = await DashboardSummary.from_mongo(
-#        mongo_client.db["dashboards"].find_one({"owner": user_id})
-#    )
-#    if dashboard:
-#        log.debug("PRIVATE DASHBOARD")
-#        log.debug(dashboard)
-#        return dashboard
-#    else:
-#        log.error('Dashboard get error')
-#        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 @router.patch("/{dashboard_id}", description="Update a dashboard", response_model_exclude_defaults=True)
 async def update_dashboard(dashboard_id: UUID,

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -111,7 +111,7 @@ async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Missing user data"
-        ) 
+        )
 
     dashboard = await DashboardSummary.from_mongo(
         mongo_client.db["dashboards"].find_one({"owner": user_id})
@@ -140,9 +140,7 @@ async def get_dashboard(dashboard_id: UUID,
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         else:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
-
-
-#@router.patch("/private", description="Update a private dashboard")
+        
 
 
 @router.patch("/{dashboard_id}", description="Update a dashboard", response_model_exclude_defaults=True)
@@ -234,6 +232,8 @@ async def update_dashboard(dashboard_id: UUID,
 async def get_widget_data(dashboard_id: UUID, widget_type: str,
                           user: UserInfo | None = Depends(get_current_user)):
     dashboard = await get_dashboard(dashboard_id, user)
+    log.debug('get_widget_data')
+    log.debug(dashboard)
 
     # fastapi_cache doesn't seem to preserve pydantic models and instead returns dicts, so converting
     # dashboard to the expected model type if it is just a dict, so that dashboard.widgets doesn't

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -56,6 +56,7 @@ async def list_dashboards(workset_manager: WorksetManager,
             mongo_client.db["dashboards"].find({"owner": config.TORCHLITE_UID, "isShared": True}).to_list(1000)
         )
         log.debug('returning featured worksets')
+        log.debug(workset_manager.public_worksets)
         return await workset_manager.align_featured_worksets(shared_torchlite_worksets)
 
     if not user:

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -122,18 +122,20 @@ async def get_dashboard(dashboard_id: UUID,
         
 @router.get("/private", description="Retrieve a private dashboard", response_model_exclude_defaults=True)
 async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
-    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
-
-    dashboard = await DashboardSummary.from_mongo(
-        mongo_client.db["dashboards"].find_one({"owner": user_id})
-    )
-    if dashboard:
-        log.debug("PRIVATE DASHBOARD")
-        log.debug(dashboard)
-        return dashboard
-    else:
-        log.error('Dashboard get error')
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    log.debug("get_private_dashboard")
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) 
+#    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
+#
+#    dashboard = await DashboardSummary.from_mongo(
+#        mongo_client.db["dashboards"].find_one({"owner": user_id})
+#    )
+#    if dashboard:
+#        log.debug("PRIVATE DASHBOARD")
+#        log.debug(dashboard)
+#        return dashboard
+#    else:
+#        log.error('Dashboard get error')
+#        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 @router.patch("/{dashboard_id}", description="Update a dashboard", response_model_exclude_defaults=True)
 async def update_dashboard(dashboard_id: UUID,

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -70,6 +70,7 @@ async def list_dashboards(workset_manager: WorksetManager,
     if user_id != owner:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     log.debug('returning owner worksets')
+    log.debug(await DashboardSummary.from_mongo(mongo_client.db["dashboards"].find({"owner": owner}).to_list(1000)))
     return await DashboardSummary.from_mongo(
         mongo_client.db["dashboards"].find({"owner": owner}).to_list(1000)
     )

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -154,9 +154,18 @@ async def update_dashboard(dashboard_id: UUID,
     log.debug(dashboard_patch_update)
     log.debug(dashboard_id)
     log.debug(user_id)
+    if user_id:
+        #The dashboard_id value is whatever the stored unauthenticated session dashboard was.
+        #Keeping that for now for the sake of consistency with GET and because I'm afraid it may
+        #be involved in how the page reloads when logging out, but we may want to get rid of 
+        #dashboard_id from patch calls when authenticated in the future
+        filter={"owner": user_id}
+    else:
+        filter={"_id": dashboard_id, "owner": user_id}
+
     dashboard = await DashboardSummary.from_mongo(
         mongo_client.db["dashboards"].find_one_and_update(
-            filter={"_id": dashboard_id, "owner": user_id},
+            filter=filter,
             update={"$set": dashboard_patch_update.to_mongo(exclude_unset=False)},
             return_document=ReturnDocument.AFTER
         )

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -117,6 +117,7 @@ async def update_dashboard(dashboard_id: UUID,
                            workset_manager: WorksetManager,
                            user_access_token: UserInfo | None = Depends(get_user_access_token)) -> DashboardSummary:
     log.debug('update_dashboard')
+    log.debug(dashboard_id)
     log.debug(dashboard_patch)
     user = await get_current_user(user_access_token)
     log.debug('a')

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -157,6 +157,7 @@ async def update_dashboard(dashboard_id: UUID,
         elif dashboard.owner != user_id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
         else:
+            log.error(f"Dashboard patch error: {dashboard}")
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -117,6 +117,7 @@ async def update_dashboard(dashboard_id: UUID,
                            workset_manager: WorksetManager,
                            user_access_token: UserInfo | None = Depends(get_user_access_token)) -> DashboardSummary:
     log.debug('update_dashboard')
+    log.debug(dashboard_patch)
     user = await get_current_user(user_access_token)
     log.debug('a')
     await workset_manager.get_public_worksets()
@@ -171,6 +172,8 @@ async def update_dashboard(dashboard_id: UUID,
             log.debug('o')
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         elif dashboard.owner != user_id:
+            log.debug(dashboard.owner)
+            log.debug(user_id)
             log.debug('p')
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
         else:

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -130,6 +130,10 @@ async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user
     if dashboard:
         log.debug("PRIVATE DASHBOARD")
         log.debug(dashboard)
+        return dashboard
+    else:
+        log.error('Dashboard get error')
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 @router.patch("/{dashboard_id}", description="Update a dashboard", response_model_exclude_defaults=True)
 async def update_dashboard(dashboard_id: UUID,

--- a/htrc/torchlite/routers/dashboards.py
+++ b/htrc/torchlite/routers/dashboards.py
@@ -105,19 +105,18 @@ async def create_dashboard(dashboard_create: DashboardCreate,
 @router.get("/private", description="Retrieve a private dashboard", response_model_exclude_defaults=True)
 async def get_private_dashboard(user: UserInfo | None = Depends(get_current_user)) -> DashboardSummary:
     log.debug("get_private_dashboard")
-    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) 
-#    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
-#
-#    dashboard = await DashboardSummary.from_mongo(
-#        mongo_client.db["dashboards"].find_one({"owner": user_id})
-#    )
-#    if dashboard:
-#        log.debug("PRIVATE DASHBOARD")
-#        log.debug(dashboard)
-#        return dashboard
-#    else:
-#        log.error('Dashboard get error')
-#        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    user_id = UUID(user.get("htrc-guid", user.sub)) if user else None
+
+    dashboard = await DashboardSummary.from_mongo(
+        mongo_client.db["dashboards"].find_one({"owner": user_id})
+    )
+    if dashboard:
+        log.debug("PRIVATE DASHBOARD")
+        log.debug(dashboard)
+        return dashboard
+    else:
+        log.error('Dashboard get error')
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @router.get("/{dashboard_id}", description="Retrieve a dashboard", response_model_exclude_defaults=True)

--- a/htrc/torchlite/routers/worksets.py
+++ b/htrc/torchlite/routers/worksets.py
@@ -38,8 +38,8 @@ async def list_worksets(workset_manager: WorksetManager, user_access_token: Anno
     featured_worksets = workset_manager.get_featured_worksets()
     user_worksets = await workset_manager.get_user_worksets(user_access_token)
 
-    return {'public': sorted(list(public_worksets.values()), key=lambda d: d.name),
-            'featured': sorted(list(featured_worksets.values()), key=lambda d: d.name), 
+    return {'public': sorted(list(public_worksets.values()), key=lambda d: d.name) if public_worksets else [],
+            'featured': sorted(list(featured_worksets.values()), key=lambda d: d.name) if featured_worksets else [], 
             'user': sorted(list(user_worksets.values()), key=lambda d: d.name) if user_worksets else []}
 
 

--- a/htrc/torchlite/routers/worksets.py
+++ b/htrc/torchlite/routers/worksets.py
@@ -67,7 +67,7 @@ async def get_workset_metadata(imported_id: str, workset_manager: WorksetManager
             mongo_client.db["id-mappings"].insert_one({"importedId": UUID(imported_id), "worksetId": ef_wsid})
         except EfApiError:
             log.error(f"Could not build workset from given volumes")
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Workset not found")
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Could not build workset from given volumes")
 
     volumes = await ef_api.get_workset_metadata(ef_wsid)
     try:

--- a/htrc/torchlite/routers/worksets.py
+++ b/htrc/torchlite/routers/worksets.py
@@ -76,7 +76,7 @@ async def get_workset_metadata(imported_id: str, workset_manager: WorksetManager
         try:
             workset = (await workset_manager.get_user_worksets(user_access_token))[imported_id]
         except (KeyError, TypeError):
-            log.error(f"Workset not found for {imported_id}")
+            log.error(f"Workset not found for  {imported_id}")
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workset not found")
 
     volumes_meta = [torchlite_volume_meta_from_ef(vol) for vol in volumes]

--- a/htrc/torchlite/routers/worksets.py
+++ b/htrc/torchlite/routers/worksets.py
@@ -55,7 +55,12 @@ async def get_workset_metadata(imported_id: str, workset_manager: WorksetManager
         try:
             imported_volumes = await workset_manager.get_public_workset_volumes(imported_id)
         except JSONDecodeError:
-            imported_volumes = await workset_manager.get_user_workset_volumes(imported_id,user_access_token)
+            try:
+                imported_volumes = await workset_manager.get_user_workset_volumes(imported_id,user_access_token)
+            except JSONDecodeError:
+                log.error(f"Could not retrieve volumes from Analytics Gateway for workset {imported_id}")
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workset not found")
+            
         ef_wsid = await ef_api.create_workset(' '.join(imported_volumes))
         mongo_client.db["id-mappings"].insert_one({"importedId": UUID(imported_id), "worksetId": ef_wsid})
 

--- a/htrc/torchlite/routers/worksets.py
+++ b/htrc/torchlite/routers/worksets.py
@@ -66,7 +66,7 @@ async def get_workset_metadata(imported_id: str, workset_manager: WorksetManager
             ef_wsid = await ef_api.create_workset(' '.join(imported_volumes))
             mongo_client.db["id-mappings"].insert_one({"importedId": UUID(imported_id), "worksetId": ef_wsid})
         except EfApiError:
-            log.error(f"Could not build workset from given volumes")
+            log.error("Could not build workset from given volumes")
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Could not build workset from given volumes")
 
     volumes = await ef_api.get_workset_metadata(ef_wsid)


### PR DESCRIPTION
Send forward meaningful error codes so that the frontend can display reasoning for why widgets aren't loading. Also update to handle some authenticated requests without sending the unused importedId/worksetId in order to allow the user to select a different workset when the current selected one cannot load.