### PR TITLE
Fix Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- API calls to Wikidata Query Service by adding User-Agent header
+
 ## [0.3.1] – 2025-05-19
 
 ### Changed

--- a/htrc/torchlite/widgets/mapping_contributor_data.py
+++ b/htrc/torchlite/widgets/mapping_contributor_data.py
@@ -91,7 +91,8 @@ class MappingContributorDataWidget(WidgetBase):
         data = await http.get(
             cls.WIKIDATA_URL,
             params={'query': query},
-            headers={'Accept': 'application/sparql-results+json'}
+            headers={'Accept': 'application/sparql-results+json',
+                     'User-Agent': 'TORCHLITE / 0.3.2 HathiTrust Research Center'}
         )
         data = data.json()
 


### PR DESCRIPTION
Calls to Wikidata Query Service broke. Adding a "User-Agent" heading that identifies who we are restored access to the API.